### PR TITLE
fix: Keep FileOffset opened only the needed time

### DIFF
--- a/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
+++ b/connect/runtime/src/main/java/org/apache/kafka/connect/storage/FileOffsetBackingStore.java
@@ -68,34 +68,37 @@ public class FileOffsetBackingStore extends MemoryOffsetBackingStore {
 
     @SuppressWarnings("unchecked")
     private void load() {
+        Object obj = null;
         try (SafeObjectInputStream is = new SafeObjectInputStream(Files.newInputStream(file.toPath()))) {
-            Object obj = is.readObject();
-            if (!(obj instanceof HashMap))
-                throw new ConnectException("Expected HashMap but found " + obj.getClass());
-            Map<byte[], byte[]> raw = (Map<byte[], byte[]>) obj;
-            data = new HashMap<>();
-            for (Map.Entry<byte[], byte[]> mapEntry : raw.entrySet()) {
-                ByteBuffer key = (mapEntry.getKey() != null) ? ByteBuffer.wrap(mapEntry.getKey()) : null;
-                ByteBuffer value = (mapEntry.getValue() != null) ? ByteBuffer.wrap(mapEntry.getValue()) : null;
-                data.put(key, value);
-            }
+            obj = is.readObject();
         } catch (NoSuchFileException | EOFException e) {
             // NoSuchFileException: Ignore, may be new.
             // EOFException: Ignore, this means the file was missing or corrupt
         } catch (IOException | ClassNotFoundException e) {
             throw new ConnectException(e);
         }
+
+        if (!(obj instanceof HashMap))
+            throw new ConnectException("Expected HashMap but found " + obj.getClass());
+        Map<byte[], byte[]> raw = (Map<byte[], byte[]>) obj;
+        data = new HashMap<>();
+        for (Map.Entry<byte[], byte[]> mapEntry : raw.entrySet()) {
+            ByteBuffer key = (mapEntry.getKey() != null) ? ByteBuffer.wrap(mapEntry.getKey()) : null;
+            ByteBuffer value = (mapEntry.getValue() != null) ? ByteBuffer.wrap(mapEntry.getValue()) : null;
+            data.put(key, value);
+        }
     }
 
     @Override
     protected void save() {
+        Map<byte[], byte[]> raw = new HashMap<>();
+        for (Map.Entry<ByteBuffer, ByteBuffer> mapEntry : data.entrySet()) {
+            byte[] key = (mapEntry.getKey() != null) ? mapEntry.getKey().array() : null;
+            byte[] value = (mapEntry.getValue() != null) ? mapEntry.getValue().array() : null;
+            raw.put(key, value);
+        }
+
         try (ObjectOutputStream os = new ObjectOutputStream(Files.newOutputStream(file.toPath()))) {
-            Map<byte[], byte[]> raw = new HashMap<>();
-            for (Map.Entry<ByteBuffer, ByteBuffer> mapEntry : data.entrySet()) {
-                byte[] key = (mapEntry.getKey() != null) ? mapEntry.getKey().array() : null;
-                byte[] value = (mapEntry.getValue() != null) ? mapEntry.getValue().array() : null;
-                raw.put(key, value);
-            }
             os.writeObject(raw);
         } catch (IOException e) {
             throw new ConnectException(e);


### PR DESCRIPTION
In another project we are working on, we have faced an issue when trying to read the file at the same time it's being writen by a heavy process.

This change is already applied in our repository, surpassing errors on corrupted file, but we think this change can be beneficial for other teams or projects.

It's supper simple, just move out from the `try-catch` block everything that is not related with IO operations (type checks, in memory object loops, ...). That frees the resource and, if it got write before closing, we don't face a `java.io.StreamCorruptedException: unexpected EOF in middle of data block` exception.

### Committer Checklist (excluded from commit message)
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation (including upgrade notes)
